### PR TITLE
[#1] Docker 이미지 최적화

### DIFF
--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -98,7 +98,7 @@ jobs:
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
           script: |
-            cd boolock/web31-BooLock
+            cd boolock/refactor-web31-BooLock
             git checkout dev
             git pull origin dev
 

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -2,15 +2,15 @@ FROM base-image AS frontend-build
 
 WORKDIR /app/apps/client
 COPY ./apps/client .
-RUN pnpm install --offline --frozen-lockfile \
+RUN pnpm install --offline --frozen-lockfile &&\
   pnpm run build
 
 FROM nginx:alpine AS frontend
 
-COPY /apps/client/nginx.conf /etc/nginx/conf.d/ \
-  /apps/client/ssl /etc/nginx/
-RUN chmod 644 /etc/nginx/ssl/fullchain.pem \ 
-  chmod 600 /etc/nginx/ssl/privkey.pem \ 
+COPY /apps/client/nginx.conf /etc/nginx/conf.d/ 
+COPY /apps/client/ssl /etc/nginx/
+RUN chmod 644 /etc/nginx/ssl/fullchain.pem &&\ 
+  chmod 600 /etc/nginx/ssl/privkey.pem &&\ 
   chown -R nginx:nginx /usr/share/nginx/html /etc/nginx/ssl
 
 COPY --from=frontend-build /app/apps/client/dist /usr/share/nginx/html/

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -7,8 +7,8 @@ RUN pnpm install --offline --frozen-lockfile &&\
 
 FROM nginx:alpine AS frontend
 
-COPY /apps/client/nginx.conf /etc/nginx/conf.d/ 
-COPY /apps/client/ssl /etc/nginx/
+COPY /apps/client/nginx.conf /etc/nginx/conf.d/default.conf
+COPY /apps/client/ssl /etc/nginx/ssl
 RUN chmod 644 /etc/nginx/ssl/fullchain.pem &&\ 
   chmod 600 /etc/nginx/ssl/privkey.pem &&\ 
   chown -R nginx:nginx /usr/share/nginx/html /etc/nginx/ssl

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -1,19 +1,20 @@
 FROM base-image AS frontend-build
+
 WORKDIR /app/apps/client
 COPY ./apps/client .
-COPY --from=base-image /app/packages /app/packages
-RUN pnpm install --offline --frozen-lockfile
-RUN pnpm run build
+RUN pnpm install --offline --frozen-lockfile \
+  pnpm run build
 
 FROM nginx:alpine AS frontend
-COPY --from=frontend-build /app/apps/client/dist /usr/share/nginx/html
-COPY /apps/client/nginx.conf /etc/nginx/conf.d/default.conf
-COPY /apps/client/ssl /etc/nginx/ssl
 
-RUN chmod -R 755 /usr/share/nginx/html
-RUN chmod 644 /etc/nginx/ssl/fullchain.pem
-RUN chmod 600 /etc/nginx/ssl/privkey.pem
-RUN chown -R nginx:nginx /usr/share/nginx/html /etc/nginx/ssl
+COPY /apps/client/nginx.conf /etc/nginx/conf.d/ \
+  /apps/client/ssl /etc/nginx/
+RUN chmod 644 /etc/nginx/ssl/fullchain.pem \ 
+  chmod 600 /etc/nginx/ssl/privkey.pem \ 
+  chown -R nginx:nginx /usr/share/nginx/html /etc/nginx/ssl
+
+COPY --from=frontend-build /app/apps/client/dist /usr/share/nginx/html/
+RUN chmod -R 755 /usr/share/nginx/html 
 
 EXPOSE 80 443
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -28,7 +28,6 @@
     "react-hot-toast": "^2.4.1",
     "react-router-dom": "^6.27.0",
     "react-spinners": "^0.14.1",
-    "react-youtube": "^10.1.0",
     "storybook": "^8.4.1",
     "uuid": "^11.0.3",
     "zustand": "^5.0.1"
@@ -55,7 +54,6 @@
     "eslint-plugin-react-refresh": "^0.4.14",
     "eslint-plugin-storybook": "^0.11.0",
     "postcss": "^8.4.47",
-    "prop-types": "15.8.1",
     "tailwindcss": "^3.4.14",
     "vite": "^5.4.10",
     "vite-plugin-svgr": "^4.3.0"

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -10,8 +10,9 @@ RUN pnpm install --offline --frozen-lockfile && \
 FROM node:20-alpine AS backend
 
 WORKDIR /app/apps/server
-COPY --from=backend-build /app/apps/server/package.json /app/apps/server/node_modules /app/pnpm-workspace.yaml /app/packages ./
-COPY ./apps/server/.env ./
+COPY --from=backend-build /app/packages ./packages
+COPY --from=backend-build /app/apps/server/package.json /app/pnpm-workspace.yaml /apps/server/.env ./
+COPY --from=backend-build /app/apps/server/node_modules ./node_modules
 COPY --from=backend-build /app/apps/server/dist ./dist
 
 RUN npm install -g pnpm && pnpm prune --prod

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -12,6 +12,7 @@ FROM node:20-alpine AS backend
 WORKDIR /app/apps/server
 COPY --from=backend-build /app/apps/server/dist ./dist
 COPY --from=backend-build /app/apps/server/package.json ./package.json
+COPY --from=backend-build /app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY ./apps/server/.env ./
 
 RUN npm install -g pnpm && pnpm install --offline --production --frozen-lockfile

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app/apps/server
 COPY ./apps/server .
 
 RUN pnpm install --offline --frozen-lockfile && \ 
-  pnpm swagger-auto && \
   pnpm run build
 
 FROM node:20-alpine AS backend

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -3,7 +3,8 @@ FROM base-image AS backend-build
 WORKDIR /app/apps/server
 COPY ./apps/server .
 
-RUN pnpm install --offline --frozen-lockfile \ pnpm run build
+RUN pnpm install --offline --frozen-lockfile &&\ 
+  pnpm run build
 
 FROM node:20-alpine AS backend
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app/apps/server
 COPY ./apps/server .
 
 RUN pnpm install --offline --frozen-lockfile &&\ 
+  pnpm swagger-auto && \
   pnpm run build
 
 FROM node:20-alpine AS backend

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app/apps/server
 COPY --from=backend-build /app/apps/server/dist ./dist
 COPY --from=backend-build /app/apps/server/package.json ./package.json
 COPY --from=backend-build /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=backend-build /app/packages ./packages
 COPY ./apps/server/.env ./
 
 RUN npm install -g pnpm && pnpm fetch --prod && pnpm install --offline --prod

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -10,15 +10,10 @@ RUN pnpm install --offline --frozen-lockfile && \
 FROM node:20-alpine AS backend
 
 WORKDIR /app/apps/server
-COPY --from=backend-build /app/apps/server/package.json \
-  /app/apps/server/node_modules \
-  /app/pnpm-workspace.yaml \
-  /app/packages \
-  ./
+COPY --from=backend-build /app/apps/server/package.json /app/apps/server/node_modules /app/pnpm-workspace.yaml /app/packages ./
 COPY ./apps/server/.env ./
 COPY --from=backend-build /app/apps/server/dist ./dist
 
-
 RUN npm install -g pnpm && pnpm prune --prod
 
-CMD ["node", "dist/index.js"]
+CMD ["pnpm", "start"]

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -3,15 +3,17 @@ FROM base-image AS backend-build
 WORKDIR /app/apps/server
 COPY ./apps/server .
 
-RUN pnpm install --offline --frozen-lockfile &&\ 
+RUN pnpm install --offline --frozen-lockfile && \ 
   pnpm swagger-auto && \
   pnpm run build
 
 FROM node:20-alpine AS backend
 
 WORKDIR /app/apps/server
-COPY --from=backend-build /app/apps/server/dist .
+COPY --from=backend-build /app/apps/server/dist ./dist
+COPY --from=backend-build /app/apps/server/package.json ./package.json
+COPY ./apps/server/.env ./
 
-RUN pnpm install --offline --production --frozen-lockfile
+RUN npm install -g pnpm && pnpm install --offline --production --frozen-lockfile
 
 CMD ["pnpm", "start"]

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,12 +1,15 @@
 FROM base-image AS backend-build
 
 WORKDIR /app/apps/server
-
 COPY ./apps/server .
-COPY --from=base-image /app/packages /app/packages
 
-RUN pnpm install --offline --frozen-lockfile
-RUN pnpm swagger-auto
-RUN pnpm run build
+RUN pnpm install --offline --frozen-lockfile \ pnpm run build
 
-CMD ["pnpm", "run", "start"]
+FROM node:20-alpine AS backend
+
+WORKDIR /app/apps/server
+COPY --from=backend-build /app/apps/client/dist .
+
+RUN pnpm install --offline --production --frozen-lockfile
+
+CMD ["pnpm", "start"]

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -10,7 +10,7 @@ RUN pnpm install --offline --frozen-lockfile &&\
 FROM node:20-alpine AS backend
 
 WORKDIR /app/apps/server
-COPY --from=backend-build /app/apps/client/dist .
+COPY --from=backend-build /app/apps/server/dist .
 
 RUN pnpm install --offline --production --frozen-lockfile
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -11,10 +11,11 @@ FROM node:20-alpine AS backend
 
 WORKDIR /app/apps/server
 COPY --from=backend-build /app/apps/server/dist ./dist
-# COPY --from=backend-build /app/apps/server/package.json ./package.json
+COPY --from=backend-build /app/apps/server/package.json ./package.json
 COPY --from=backend-build /app/apps/server/node_modules ./node_modules
+COPY --from=backend-build /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 # COPY --from=backend-build /app/pnpm-lock.yaml ./pnpm-lock.yaml
-# COPY --from=backend-build /app/packages ./packages
+COPY --from=backend-build /app/packages ./packages
 COPY ./apps/server/.env ./
 
 RUN npm install -g pnpm && pnpm prune --prod

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -10,13 +10,14 @@ RUN pnpm install --offline --frozen-lockfile && \
 FROM node:20-alpine AS backend
 
 WORKDIR /app/apps/server
-COPY --from=backend-build /app/apps/server/dist ./dist
-COPY --from=backend-build /app/apps/server/package.json ./package.json
-COPY --from=backend-build /app/apps/server/node_modules ./node_modules
-COPY --from=backend-build /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
-# COPY --from=backend-build /app/pnpm-lock.yaml ./pnpm-lock.yaml
-COPY --from=backend-build /app/packages ./packages
+COPY --from=backend-build /app/apps/server/package.json \
+  /app/apps/server/node_modules \
+  /app/pnpm-workspace.yaml \
+  /app/packages \
+  ./
 COPY ./apps/server/.env ./
+COPY --from=backend-build /app/apps/server/dist ./dist
+
 
 RUN npm install -g pnpm && pnpm prune --prod
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -11,11 +11,12 @@ FROM node:20-alpine AS backend
 
 WORKDIR /app/apps/server
 COPY --from=backend-build /app/apps/server/dist ./dist
-COPY --from=backend-build /app/apps/server/package.json ./package.json
-COPY --from=backend-build /app/pnpm-lock.yaml ./pnpm-lock.yaml
-COPY --from=backend-build /app/packages ./packages
+# COPY --from=backend-build /app/apps/server/package.json ./package.json
+COPY --from=backend-build /app/apps/server/node_modules ./node_modules
+# COPY --from=backend-build /app/pnpm-lock.yaml ./pnpm-lock.yaml
+# COPY --from=backend-build /app/packages ./packages
 COPY ./apps/server/.env ./
 
-RUN npm install -g pnpm && pnpm fetch --prod && pnpm install --offline --prod
+RUN npm install -g pnpm && pnpm prune --prod
 
-CMD ["pnpm", "start"]
+CMD ["node", "dist/index.js"]

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -11,7 +11,7 @@ FROM node:20-alpine AS backend
 
 WORKDIR /app/apps/server
 COPY --from=backend-build /app/packages ./packages
-COPY --from=backend-build /app/apps/server/package.json /app/pnpm-workspace.yaml /apps/server/.env ./
+COPY --from=backend-build /app/apps/server/package.json /app/pnpm-workspace.yaml /app/apps/server/.env ./
 COPY --from=backend-build /app/apps/server/node_modules ./node_modules
 COPY --from=backend-build /app/apps/server/dist ./dist
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -15,6 +15,6 @@ COPY --from=backend-build /app/apps/server/package.json ./package.json
 COPY --from=backend-build /app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY ./apps/server/.env ./
 
-RUN npm install -g pnpm && pnpm install --offline --production --frozen-lockfile
+RUN npm install -g pnpm && pnpm fetch --prod && pnpm install --offline --prod
 
 CMD ["pnpm", "start"]

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "mongoose": "^8.8.0",
+    "multer": "1.4.5-lts.1",
     "tunnel-ssh": "^5.1.2"
   },
   "devDependencies": {
@@ -26,7 +27,6 @@
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.7",
     "aws-sdk": "^2.1692.0",
-    "multer": "1.4.5-lts.1",
     "nodemon": "^3.1.7",
     "swagger-autogen": "^2.23.7",
     "swagger-jsdoc": "^6.2.8",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -3,8 +3,6 @@ import './config/dbConnection';
 import cors from 'cors';
 import express from 'express';
 import routes from './routes/v1/index';
-import swaggerDocument from './docs/swagger-output.json';
-import { swaggerUi } from './docs/swagger';
 import 'dotenv/config';
 import { errorMiddleware } from './middlewares/errorMiddleware';
 
@@ -18,7 +16,13 @@ app.use(
 app.use(express.json());
 
 app.use('/api', routes);
-app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+
+if (process.env.NODE_ENV !== 'production') {
+  const swaggerDocument = require('./docs/swagger-output.json');
+  const { swaggerUi } = require('./docs/swagger');
+  app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+}
+
 app.use(errorMiddleware);
 
 export default app;

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -8,5 +8,5 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "docs"]
 }

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -8,5 +8,5 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["node_modules", "dist", "docs"]
+  "exclude": ["node_modules", "dist", "src/docs"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       mongoose:
         specifier: ^8.8.0
         version: 8.8.1
+      multer:
+        specifier: 1.4.5-lts.1
+        version: 1.4.5-lts.1
       tunnel-ssh:
         specifier: ^5.1.2
         version: 5.1.2
@@ -217,9 +220,6 @@ importers:
       aws-sdk:
         specifier: ^2.1692.0
         version: 2.1692.0
-      multer:
-        specifier: 1.4.5-lts.1
-        version: 1.4.5-lts.1
       nodemon:
         specifier: ^3.1.7
         version: 3.1.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       react-spinners:
         specifier: ^0.14.1
         version: 0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-youtube:
-        specifier: ^10.1.0
-        version: 10.1.0(react@18.3.1)
       storybook:
         specifier: ^8.4.1
         version: 8.4.2(prettier@3.3.3)
@@ -156,9 +153,6 @@ importers:
       postcss:
         specifier: ^8.4.47
         version: 8.4.49
-      prop-types:
-        specifier: 15.8.1
-        version: 15.8.1
       tailwindcss:
         specifier: ^3.4.14
         version: 3.4.14(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.3))
@@ -3055,9 +3049,6 @@ packages:
     resolution: {integrity: sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==}
     engines: {node: '>=18.0.0'}
 
-  load-script@1.0.0:
-    resolution: {integrity: sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==}
-
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -3669,12 +3660,6 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
 
-  react-youtube@10.1.0:
-    resolution: {integrity: sha512-ZfGtcVpk0SSZtWCSTYOQKhfx5/1cfyEW1JN/mugGNfAxT3rmVJeMbGpA9+e78yG21ls5nc/5uZJETE3cm3knBg==}
-    engines: {node: '>= 14.x'}
-    peerDependencies:
-      react: '>=0.14.1'
-
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -3839,9 +3824,6 @@ packages:
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
-
-  sister@3.0.2:
-    resolution: {integrity: sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -4419,9 +4401,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  youtube-player@5.5.2:
-    resolution: {integrity: sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==}
 
   z-schema@5.0.5:
     resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
@@ -5017,7 +4996,7 @@ snapshots:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5100,7 +5079,7 @@ snapshots:
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -5360,7 +5339,7 @@ snapshots:
   '@eslint/config-array@0.18.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5370,7 +5349,7 @@ snapshots:
   '@eslint/eslintrc@3.1.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -6438,7 +6417,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.14.0
       '@typescript-eslint/visitor-keys': 8.14.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -6554,7 +6533,7 @@ snapshots:
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7010,6 +6989,10 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.3.7(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -7194,7 +7177,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.24.0):
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7
       esbuild: 0.24.0
     transitivePeerDependencies:
       - supports-color
@@ -7328,7 +7311,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.5
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -7667,14 +7650,14 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7972,8 +7955,6 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
-
-  load-script@1.0.0: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -8484,15 +8465,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-youtube@10.1.0(react@18.3.1):
-    dependencies:
-      fast-deep-equal: 3.1.3
-      prop-types: 15.8.1
-      react: 18.3.1
-      youtube-player: 5.5.2
-    transitivePeerDependencies:
-      - supports-color
-
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -8716,8 +8688,6 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.6.3
-
-  sister@3.0.2: {}
 
   slash@3.0.0: {}
 
@@ -9329,14 +9299,6 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
-
-  youtube-player@5.5.2:
-    dependencies:
-      debug: 2.6.9
-      load-script: 1.0.0
-      sister: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   z-schema@5.0.5:
     dependencies:


### PR DESCRIPTION
## 🔗 #1 

## 🙋‍ Summary (요약) 
- Docker 이미지 최적화

## 😎 Description (변경사항)
### 백엔드 이미지 최적화
- 멀티 스테이지 빌드 기법을 이용해서 `backend-build`, `backend` 이미지를 별도로 분리하였고, 최종적으로 `backend` 이미지만 실행시켰습니다.
- 별도로 분리시킨 이유는 server build 파일을 만들 때는 devDependencies도 포함한 채로 라이브러리들이 설치되어야해서 라이브러리의 크기가 너무 커져 도커 이미지도 커지기 때문입니다.
- 최종 이미지인 `backend` 이미지에서는 production dependencies만 남겨 이미지 사이즈를 줄였습니다.
- 스웨거파일은 실제 배포환경에서는 포함시킬 필요가 없다고 생각해서 `tsconfig.json`의 exclude에 docs 폴더를 포함시켜 빌드파일 만들 시 docs 폴더가 포함되지 않게 하였습니다. 
  - 그리고 `NODE_ENV=production` 일 경우 
  ```ts
  if (process.env.NODE_ENV !== 'production') {
    const swaggerDocument = require('./docs/swagger-output.json');
    const { swaggerUi } = require('./docs/swagger');
    app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
  }
  ```
  - 이렇게 route가 할당되지 않게 하였습니다.
  => 빌드 파일을 실행시키기 위해 필수적으로 실행해야했던 `pnpm swagger-auto` 명령어를 실행하지 않아도 되게 하여 이미지 사이즈를 줄였습니다.
- 필요없는 레이어를 제거하거나, 명령어 체이닝으로 레이어를 합쳐 총 레이어 수를 줄여 이미지 사이즈를 줄였습니다.
  ```Dockerfile
  FROM base-image AS backend-build
  
  WORKDIR /app/apps/server
  COPY ./apps/server .
  
  RUN pnpm install --offline --frozen-lockfile && \ 
    pnpm run build
  
  FROM node:20-alpine AS backend
  
  WORKDIR /app/apps/server
  COPY --from=backend-build /app/packages ./packages
  COPY --from=backend-build /app/apps/server/package.json /app/pnpm-workspace.yaml /app/apps/server/.env ./
  COPY --from=backend-build /app/apps/server/node_modules ./node_modules
  COPY --from=backend-build /app/apps/server/dist ./dist
  
  RUN npm install -g pnpm && pnpm prune --prod
  
  CMD ["pnpm", "start"]
  ```
  - `backend-build` 이미지는 pnpm 패키지들을 다운받은 base-image를 그대로 사용하기에 `COPY --from=base-image /app/packages /app/packages` 레이어는 제거했습니다.
  ```Dockerfile
  RUN pnpm install --offline --frozen-lockfile 
  RUN pnpm run build
  ```
  - 분리되어있던 pnpm 명령어 실행 레이어를 `RUN pnpm install --offline --frozen-lockfile && pnpm run build` 한 레이어로 합쳐주었습니다.
  - 이외에도 합칠 수 있는 레이어들은 합쳐 총 레이어의 수를 줄여주었습니다.

### 프론트엔드 이미지 최적화
- 프론트엔드 이미지는 이미 멀티 스테이지 빌드로 이루어져 있어 최종이미지 사이즈 자체는 작은 편이었기에 레이어수를 줄이고, 캐싱 구조를 조금 개선시키는 방향으로 수정하였습니다.
```Dockerfile
FROM base-image AS frontend-build

WORKDIR /app/apps/client
COPY ./apps/client .
RUN pnpm install --offline --frozen-lockfile &&\
  pnpm run build

FROM nginx:alpine AS frontend

COPY /apps/client/nginx.conf /etc/nginx/conf.d/default.conf
COPY /apps/client/ssl /etc/nginx/ssl
RUN chmod 644 /etc/nginx/ssl/fullchain.pem &&\ 
  chmod 600 /etc/nginx/ssl/privkey.pem &&\ 
  chown -R nginx:nginx /usr/share/nginx/html /etc/nginx/ssl

COPY --from=frontend-build /app/apps/client/dist /usr/share/nginx/html/
RUN chmod -R 755 /usr/share/nginx/html 

EXPOSE 80 443
CMD ["nginx", "-g", "daemon off;"]
```
- 백엔드 이미지와 마찬가지로 분리되어있던 pnpm 명령어 실행 레이어를 `RUN pnpm install --offline --frozen-lockfile && pnpm run build` 이렇게 한 레이어로 합쳐주었습니다.
- 최종 이미지인 `frontend`이미지에서는 nginx관련 파일들을 먼저 복사해오고 권한을 부여해주고, 이후 dist 빌드 파일을 복사해와 권한을 부여해준 후 최종실행을 하는 것으로 구조를 바꿔 변경사항이 적은 nginx파일들은 계속 캐시를 사용할 수 있게 해주었습니다.
  - +) Docker에도 레이어 캐시가 존재하는데, 상단 레이어의 소스코드에 수정사항이 생겨 캐시가 무효화된다면 하단의 레이어들도 전부 캐시가 무효화됩니다. 그래서 변경사항이 적은 레이어들은 상단에 배치하는 것이 재시작할 때 빌드속도를 줄일 수 있게 해주어 보다 효율적입니다.

### 최종 결과
- 이미지 크기 before
![image](https://github.com/user-attachments/assets/0e94a16e-930f-4c54-8aa9-2379241fa59a)

- 이미지 크기 after
![image](https://github.com/user-attachments/assets/bdad4adc-ff0f-4599-ba16-79122bd219d1)

- `backend`이미지는 631MB -> 266MB로 줄었고, `frontend`이미지는 59.4MB -> 51.6MB로 줄었습니다.

- 빌드 시간 before
![image](https://github.com/user-attachments/assets/22f7b1bb-bd22-4928-be37-b267e7aac645)

- 빌드 시간 after
![image](https://github.com/user-attachments/assets/434cdc3c-6700-4c6d-a911-5f1251f30c71)

- `backend` 이미지 실행까지 스테이지가 한 단계 늘었고, 그만큼 레이어수도 늘어나서 최종적인 빌드 시간 7초 가량 늘었습니다. (하지만 사이즈는 1/3로 줄였으니...)

### 라이브러리 정리
- 프론트의 `react-youtube` 라이브러리와 백엔드의 `prop-type` 라이브러리는 사용되는 곳이 없어 삭제했습니다.
- 백엔드의 `multer` 라이브러리는 배포 환경에서도 사용되는 라이브러리이기에 `dependencies`로 옮겼습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)
### 패키지 재설치 vs 패키지 복사 후 정리
- 최종적인 `backend` 이미지는 `base-image`를 사용하지 않고 아예 `node:20-alpine`으로 새로운 이미지를 만드는 것이고 단순히 다른 스테이지에서 파일들만 복사해올 수 있는 것이기에, 이전에 설치했던 라이브러리들을 복사하거나 설치하지 않고도 사용할 수 있는 방법은 없습니다.
- 그래서 소스파일에서 package.json 파일만 복사해와 다시 production dependencies를 재설치를 해줄지, 아니면 아예 이전 `backend-build` 이미지에서 `node_modules` 폴더를 복사해오고 devDependencies를 삭제해줄지 고민했습니다.

```Dockerfile
COPY --from=backend-build /app/apps/server/node_modules ./node_modules

RUN npm install -g pnpm && pnpm prune --prod
```
- 최종적으로는 `backend`이미지는 이렇게 `backend-build` 이미지에서 node_modules 폴더를 복사해오고 `pnpm prune --prod` 명령어를 이용하여 devDependencies 패키지들은 삭제하는 방식으로 구현되어있습니다.

- Docker 이미지 사이즈에는 shared size/unique size라는 것이 분리되어있는데, shared size는 다른 이미지들과 공유하고 있는 파일들에 대한 사이즈인 것입니다.
- 최종적인 사이즈가 두 방식 모두 비슷하다면, shared size가 큰 것이 나을 것이라고 생각하여 후자를 선택했습니다. (전자는 새로 설치되는 라이브러리들의 사이즈가 전부 unique size로 측정됩니다.)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
