### PR TITLE
[#18] useQuery, useInfiniteQuery -> useSuspenseQuery, useSuspenseInfiniteQuery 교체

### DIFF
--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -1,9 +1,10 @@
+import { ErrorPage, WorkspaceErrorPage } from '@/pages';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
-import { ToasterWithMax } from '@/shared/ui';
-import { ErrorPage } from '@/pages/ErrorPage/ErrorPage';
-import { lazy, Suspense } from 'react';
-import { Loading } from '@/shared/ui';
+import { Suspense, lazy } from 'react';
+
 import { Helmet } from 'react-helmet-async';
+import { Loading } from '@/shared/ui';
+import { ToasterWithMax } from '@/shared/ui';
 
 // lazy 로딩
 const HomePage = lazy(() =>
@@ -11,7 +12,7 @@ const HomePage = lazy(() =>
 );
 
 const WorkspacePage = lazy(() =>
-  import('@/pages/Workspacepage/WorkspacePage').then((module) => ({
+  import('@/pages/WorkspacePage/WorkspacePage').then((module) => ({
     default: module.WorkspacePage,
   }))
 );
@@ -47,12 +48,13 @@ const router = createBrowserRouter([
           <title>BooLock - 작업 공간</title>
           <meta name="description" content={`워크스페이스에서 HTML과 CSS를 연습해보세요.`} />
         </Helmet>
+
         <Suspense fallback={<Loading />}>
           <WorkspacePage />
         </Suspense>
       </>
     ),
-    errorElement: <ErrorPage />,
+    errorElement: <WorkspaceErrorPage />,
   },
   {
     path: '*',

--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -12,7 +12,7 @@ const HomePage = lazy(() =>
 );
 
 const WorkspacePage = lazy(() =>
-  import('@/pages/WorkspacePage/WorkspacePage').then((module) => ({
+  import('@/pages/Workspacepage/WorkspacePage').then((module) => ({
     default: module.WorkspacePage,
   }))
 );

--- a/apps/client/src/pages/HomePage/HomePage.tsx
+++ b/apps/client/src/pages/HomePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Banner, HomeHeader, WorkspaceContainer, WorkspaceModal } from '@/widgets';
+import { Banner, HomeHeader, WorkspaceModal, WorkspaceSection } from '@/widgets';
 import { useClassBlockStore, useLoadingStore, useWorkspaceStore } from '@/shared/store';
 
 import { Loading } from '@/shared/ui';
@@ -26,7 +26,7 @@ export const HomePage = () => {
       <div className="flex h-full w-full flex-col items-center">
         <HomeHeader />
         <Banner />
-        <WorkspaceContainer />
+        <WorkspaceSection />
         <WorkspaceModal />
       </div>
     </>

--- a/apps/client/src/pages/WorkspaceErrorPage/WorkspaceErrorPage.tsx
+++ b/apps/client/src/pages/WorkspaceErrorPage/WorkspaceErrorPage.tsx
@@ -1,0 +1,15 @@
+import { ErrorPage, NotFound } from '@/pages';
+
+import toast from 'react-hot-toast';
+import { useRouteError } from 'react-router-dom';
+
+export const WorkspaceErrorPage = () => {
+  const error: any = useRouteError();
+  const statusCode = error?.response?.statusCode || error?.status;
+  console.log('error', error);
+  if (statusCode === 404) {
+    toast.error('워크스페이스 정보 불러오기 실패');
+    return <NotFound />;
+  }
+  return <ErrorPage />;
+};

--- a/apps/client/src/pages/WorkspaceErrorPage/WorkspaceErrorPage.tsx
+++ b/apps/client/src/pages/WorkspaceErrorPage/WorkspaceErrorPage.tsx
@@ -6,7 +6,6 @@ import { useRouteError } from 'react-router-dom';
 export const WorkspaceErrorPage = () => {
   const error: any = useRouteError();
   const statusCode = error?.response?.statusCode || error?.status;
-  console.log('error', error);
   if (statusCode === 404) {
     toast.error('워크스페이스 정보 불러오기 실패');
     return <NotFound />;

--- a/apps/client/src/pages/Workspacepage/WorkspacePage.tsx
+++ b/apps/client/src/pages/Workspacepage/WorkspacePage.tsx
@@ -1,10 +1,9 @@
-import { ImageTagModal, CoachMark, WorkspaceContent, WorkspacePageHeader } from '@/widgets';
+import { CoachMark, ImageTagModal, WorkspaceContent, WorkspacePageHeader } from '@/widgets';
+import { useEffect, useLayoutEffect } from 'react';
 import { useGetWorkspace, usePreventLeaveWorkspacePage } from '@/shared/hooks';
-import { Loading } from '@/shared/ui';
-import { NotFound } from '@/pages/NotFound/NotFound';
-import { useParams } from 'react-router-dom';
-import { useLayoutEffect, useEffect } from 'react';
+
 import { useCoachMarkStore } from '@/shared/store/useCoachMarkStore';
+import { useParams } from 'react-router-dom';
 
 /**
  *
@@ -13,7 +12,7 @@ import { useCoachMarkStore } from '@/shared/store/useCoachMarkStore';
  */
 export const WorkspacePage = () => {
   const { workspaceId } = useParams();
-  const { isPending, isError } = useGetWorkspace(workspaceId as string);
+  useGetWorkspace(workspaceId as string);
   usePreventLeaveWorkspacePage();
   const { currentStep, isCoachMarkOpen, openCoachMark } = useCoachMarkStore();
   const toolboxDiv = document.querySelector('.blocklyToolboxDiv');
@@ -36,14 +35,9 @@ export const WorkspacePage = () => {
     }
   }, [currentStep, toolboxDiv]);
 
-  if (isError) {
-    return <NotFound />;
-  }
-
   return (
     <>
       <div className="flex h-screen flex-col">
-        {isPending && <Loading />}
         {isCoachMarkOpen && <CoachMark />}
         <WorkspacePageHeader />
         <WorkspaceContent />

--- a/apps/client/src/pages/index.ts
+++ b/apps/client/src/pages/index.ts
@@ -1,3 +1,5 @@
 export { HomePage } from './HomePage/HomePage';
 export { NotFound } from './NotFound/NotFound';
-export { WorkspacePage } from './Workspacepage/WorkspacePage';
+export { WorkspacePage } from './WorkspacePage/WorkspacePage';
+export { ErrorPage } from './ErrorPage/ErrorPage';
+export { WorkspaceErrorPage } from './WorkspaceErrorPage/WorkspaceErrorPage';

--- a/apps/client/src/pages/index.ts
+++ b/apps/client/src/pages/index.ts
@@ -1,5 +1,5 @@
 export { HomePage } from './HomePage/HomePage';
 export { NotFound } from './NotFound/NotFound';
-export { WorkspacePage } from './WorkspacePage/WorkspacePage';
+export { WorkspacePage } from './Workspacepage/WorkspacePage';
 export { ErrorPage } from './ErrorPage/ErrorPage';
 export { WorkspaceErrorPage } from './WorkspaceErrorPage/WorkspaceErrorPage';

--- a/apps/client/src/shared/hooks/queries/useGetWorkspace.ts
+++ b/apps/client/src/shared/hooks/queries/useGetWorkspace.ts
@@ -3,16 +3,15 @@ import { createUserId, getUserId, removeCssClassNamePrefix } from '@/shared/util
 import {
   useClassBlockStore,
   useCssPropsStore,
+  useImageModalStore,
   useResetCssStore,
   useWorkspaceChangeStatusStore,
   useWorkspaceStore,
-  useImageModalStore,
 } from '@/shared/store';
 
 import { WorkspaceApi } from '@/shared/api';
-import toast from 'react-hot-toast';
 import { useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { workspaceKeys } from '@/shared/hooks';
 
 export const useGetWorkspace = (workspaceId: string) => {
@@ -24,29 +23,19 @@ export const useGetWorkspace = (workspaceId: string) => {
   const { resetChangedStatusState } = useWorkspaceChangeStatusStore();
   const { setIsResetCssChecked } = useResetCssStore();
   const { setInitialImageMap, setInitialImageList } = useImageModalStore();
-  const { data, isPending, isError } = useQuery({
+  const { data, isPending, isError } = useSuspenseQuery({
     queryKey: workspaceKeys.detail(workspaceId),
     queryFn: () => {
+      resetChangedStatusState();
       return workspaceApi.getWorkspace(userId, workspaceId);
     },
   });
 
   useEffect(() => {
-    resetChangedStatusState();
-  }, []);
-
-  useEffect(() => {
-    if (isError) {
-      toast.error('워크스페이스 정보 불러오기 실패');
-      return;
-    }
-    if (!data) {
+    if (!isError || !data || !data.workspaceDto) {
       return;
     }
 
-    if (!data.workspaceDto) {
-      return;
-    }
     setName(data.workspaceDto.name);
     Object.keys(data.workspaceDto.totalCssPropertyObj).forEach((className) => {
       createCssClassBlock(className);

--- a/apps/client/src/shared/hooks/queries/useGetWorkspaceList.ts
+++ b/apps/client/src/shared/hooks/queries/useGetWorkspaceList.ts
@@ -1,6 +1,7 @@
-import { WorkspaceApi } from '@/shared/api';
 import { createUserId, getUserId } from '@/shared/utils';
-import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { WorkspaceApi } from '@/shared/api';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { workspaceKeys } from '@/shared/hooks';
 export const useGetWorkspaceList = () => {
   const workspaceApi = WorkspaceApi();
@@ -12,7 +13,7 @@ export const useGetWorkspaceList = () => {
     isFetchingNextPage,
     isError,
     data: workspaceList,
-  } = useInfiniteQuery({
+  } = useSuspenseInfiniteQuery({
     queryKey: workspaceKeys.list(),
     queryFn: async ({ pageParam }) => {
       const isNewUser = !getUserId();

--- a/apps/client/src/widgets/home/WorkspaceContainer/WorkspaceContainer.stories.tsx
+++ b/apps/client/src/widgets/home/WorkspaceContainer/WorkspaceContainer.stories.tsx
@@ -6,7 +6,7 @@ const meta: Meta<typeof WorkspaceContainer> = {
   title: 'widgets/home/WorkspaceContainer',
   component: WorkspaceContainer,
   parameters: {
-    layout: 'fullscreen',
+    layout: 'centered',
   },
   tags: ['autodocs'],
 };

--- a/apps/client/src/widgets/home/WorkspaceContainer/WorkspaceContainer.tsx
+++ b/apps/client/src/widgets/home/WorkspaceContainer/WorkspaceContainer.tsx
@@ -1,17 +1,16 @@
-import { EmptyWorkspace, WorkspaceGrid, WorkspaceHeader, WorkspaceList } from '@/widgets';
+import { EmptyWorkspace, WorkspaceGrid, WorkspaceList } from '@/widgets';
 import { useGetWorkspaceList, useInfiniteScroll, useVirtualScroll } from '@/shared/hooks';
 
 import { SkeletonWorkspaceList } from '@/shared/ui';
 import { TWorkspace } from '@/shared/types';
-import { WorkspaceLoadError } from '@/entities';
 
 /**
  *
  * @description
- * 워크스페이스 헤더와 그리드를 감싸는 컨테이너 컴포넌트
+ * 워크스페이스 리스트를 렌더링하는 컨테이너 컴포넌트
  */
 export const WorkspaceContainer = () => {
-  const { hasNextPage, fetchNextPage, isPending, isFetchingNextPage, isError, workspaceList } =
+  const { hasNextPage, fetchNextPage, isPending, isFetchingNextPage, workspaceList } =
     useGetWorkspaceList();
 
   const { renderedData, offsetY, totalHeight } = useVirtualScroll<TWorkspace>({
@@ -33,17 +32,8 @@ export const WorkspaceContainer = () => {
   const nextFetchTargetRef = useInfiniteScroll({ intersectionCallback: fetchCallback });
 
   return (
-    <section className="w-full max-w-[1152px] px-3 pb-48">
-      <WorkspaceHeader />
-      {isPending && (
-        <WorkspaceGrid>
-          <SkeletonWorkspaceList skeletonNum={8} />
-        </WorkspaceGrid>
-      )}
-      {isError ? (
-        <WorkspaceLoadError />
-      ) : (
-        workspaceList &&
+    <>
+      {workspaceList &&
         (workspaceList.length === 0 ? (
           <EmptyWorkspace />
         ) : (
@@ -57,11 +47,10 @@ export const WorkspaceContainer = () => {
               {isFetchingNextPage && <SkeletonWorkspaceList skeletonNum={8} />}
             </WorkspaceGrid>
           </div>
-        ))
-      )}
+        ))}
       {!isPending && !isFetchingNextPage && hasNextPage && (
         <div ref={nextFetchTargetRef} className="h-3 w-full"></div>
       )}
-    </section>
+    </>
   );
 };

--- a/apps/client/src/widgets/home/WorkspaceSection/WorkspaceSection.stories.tsx
+++ b/apps/client/src/widgets/home/WorkspaceSection/WorkspaceSection.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { WorkspaceSection } from './WorkspaceSection';
+
+const meta: Meta<typeof WorkspaceSection> = {
+  title: 'widgets/home/WorkspaceSection',
+  component: WorkspaceSection,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WorkspaceSection>;
+
+export const Default: Story = {
+  args: {
+    // propsname: value,
+  },
+};

--- a/apps/client/src/widgets/home/WorkspaceSection/WorkspaceSection.tsx
+++ b/apps/client/src/widgets/home/WorkspaceSection/WorkspaceSection.tsx
@@ -1,0 +1,20 @@
+import { WorkspaceContainer, WorkspaceHeader } from '@/widgets';
+
+import { SkeletonWorkspaceList } from '@/shared/ui';
+import { Suspense } from 'react';
+
+/**
+ *
+ * @description
+ * 워크스페이스 헤더와 컨테이너를 합친 섹션 컴포넌트
+ */
+export const WorkspaceSection = () => {
+  return (
+    <section className="w-full max-w-[1152px] px-3 pb-48">
+      <WorkspaceHeader />
+      <Suspense fallback={<SkeletonWorkspaceList skeletonNum={8} />}>
+        <WorkspaceContainer />
+      </Suspense>
+    </section>
+  );
+};

--- a/apps/client/src/widgets/index.ts
+++ b/apps/client/src/widgets/index.ts
@@ -4,8 +4,9 @@ export { WorkspaceList } from './home/WorkspaceList/WorkspaceList';
 export { WorkspaceHeader } from './home/WorkspaceHeader/WorkspaceHeader';
 export { EmptyWorkspace } from './home/EmptyWorkspace/EmptyWorkspace';
 export { WorkspaceGrid } from './home/WorkspaceGrid/WorkspaceGrid';
-export { WorkspaceContainer } from './home/WorkspaceContainer/WorkspaceContainer';
+export { WorkspaceSection } from './home/WorkspaceSection/WorkspaceSection';
 export { WorkspaceModal } from './home/WorkspaceModal/WorkspaceModal';
+export { WorkspaceContainer } from './home/WorkspaceContainer/WorkspaceContainer';
 
 export { PreviewBox } from './workspace/PreviewBox/PreviewBox';
 export { CoachMark } from './workspace/CoachMark/CoachMark';

--- a/apps/server/src/middlewares/errorMiddleware.ts
+++ b/apps/server/src/middlewares/errorMiddleware.ts
@@ -11,7 +11,6 @@ import { errorStatus } from '../utils/constants';
 
 // eslint-disable-next-line no-unused-vars
 export const errorMiddleware = (err: Error, req: Request, res: Response, _next: NextFunction) => {
-  console.log(err.constructor.name);
   const handler = errorHandlers[err.constructor.name] || errorHandlers['DefaultError'];
   console.error(err);
 

--- a/apps/server/src/middlewares/errorMiddleware.ts
+++ b/apps/server/src/middlewares/errorMiddleware.ts
@@ -1,9 +1,17 @@
-import { Request, Response, NextFunction } from 'express';
-import { CustomError } from '../utils/customError';
+import {
+  BadRequestError,
+  CustomError,
+  ForbiddenError,
+  UnauthorizedError,
+} from '../utils/customError';
+import { NextFunction, Request, Response } from 'express';
+
+import { NotFound } from '@aws-sdk/client-s3';
 import { errorStatus } from '../utils/constants';
 
 // eslint-disable-next-line no-unused-vars
 export const errorMiddleware = (err: Error, req: Request, res: Response, _next: NextFunction) => {
+  console.log(err.constructor.name);
   const handler = errorHandlers[err.constructor.name] || errorHandlers['DefaultError'];
   console.error(err);
 
@@ -18,5 +26,17 @@ const errorHandlers: { [key: string]: (err: any, res: Response) => void } = {
   },
   CustomError: (err: CustomError, res: Response) => {
     res.status(err.statusCode).json({ message: err.message });
+  },
+  NotFoundError: (err: NotFound, res: Response) => {
+    res.status(errorStatus.HTTP_404_NOT_FOUND).json({ message: err.message });
+  },
+  BadRequestError: (err: BadRequestError, res: Response) => {
+    res.status(errorStatus.HTTP_400_BAD_REQUEST).json({ message: err.message });
+  },
+  UnauthorizedError: (err: UnauthorizedError, res: Response) => {
+    res.status(errorStatus.HTTP_401_UNAUTHORIZED).json({ message: err.message });
+  },
+  ForbiddenError: (err: ForbiddenError, res: Response) => {
+    res.status(errorStatus.HTTP_403_FORBIDDEN).json({ message: err.message });
   },
 };

--- a/apps/server/src/utils/customError.ts
+++ b/apps/server/src/utils/customError.ts
@@ -10,14 +10,14 @@ export class CustomError extends Error {
 }
 
 export class NotFoundError extends CustomError {
-  constructor(message = 'Bad request') {
-    super(message, errorStatus.HTTP_400_BAD_REQUEST);
+  constructor(message = 'Resource not found') {
+    super(message, errorStatus.HTTP_404_NOT_FOUND);
   }
 }
 
 export class BadRequestError extends CustomError {
-  constructor(message = 'Resource not found') {
-    super(message, errorStatus.HTTP_404_NOT_FOUND);
+  constructor(message = 'Bad request') {
+    super(message, errorStatus.HTTP_400_BAD_REQUEST);
   }
 }
 


### PR DESCRIPTION
## 🔗 #18 

## 🙋‍ Summary (요약) 
- 기존 `useQuery`, `useInfiniteQuery`를 `Suspense`를 활용할 수 있는 `useSuspenseQuery`, `useSuspenseInfiniteQuery`로 교체하였습니다.

## 😎 Description (변경사항)
### `useQuery`, `useInfiniteQuery` -> `useSuspenseQuery`, `useSuspenseInfiniteQuery` 교체
- React의 철학인 선언적인 프로그래밍을 적극적으로 반영하고자 기존 명령형 프로그래밍 성격이 강했던 기존 방식을 Suspense를 활용한 방식으로 바꾸고자 진행한 작업입니다.
- [Suspense 관련 학습 정리](https://laced-riverbed-47c.notion.site/Suspense-4b014db5d52a4fa8ae09c80fb484f66f?pvs=4)

#### 명령적, 선언적 프로그래밍에 대한 간단한 설명
- 명령적 프로그래밍
  - **어떻게 해야 하는가?** 에 초점을 맞춘 프로그래밍 스타일
  - 작업을 수행하기 위한 절차나 명령의 흐름을 명확히 정의하는 방식
  
**예시**
```ts
if(isError)
   return <Error컴포넌트/> 
if(loading) 
  return <로딩컴포넌트/>
return  <컴포넌트 />
```
- 설명 : 에러 발생 시 Error 컴포넌트를 렌더링하고 로딩 시에는 로딩 컴포넌트를 렌더링하고 그렇지 않으면 보여주려고 한 컴포넌트를 렌더링하라고 절차를 정의함

- 선언적 프로그래밍
  - **무엇을 해야 하는가?**에 초점을 맞춘 프로그래밍 스타일
  - 결과를 정의하지만 그것을 얻는 방법(절차)은 시스템에 위임하는 방식
  
**예시**
```ts
<ErrorBoundary fallback={에러컴포넌트}>
  <Suspense fallback={로딩컴포넌트}>
      <비동기 데이터를 불러오는 컴포넌트/>
  <Suspense/>
```
- 설명 : 개발자는 UI 로직에만 집중하면 됨. 에러 처리와 로딩 처리는 `ErrorBounday`, `Suspense` 컴포넌트가 처리함 (시스템에 위임)

### `useGetWorkspace` 훅에서 `useSuspenseQuery`를 사용하도록 교체
- 기존에 사용하던 `useQuery`를 `useSuspenseQuery`로 교체함

<details>
<summary>기존 코드</summary>

```ts
export const useGetWorkspace = (workspaceId: string) => {
  const workspaceApi = WorkspaceApi();
  const userId = getUserId() || createUserId();
  const { initCssPropertyObj } = useCssPropsStore();
  const { initClassBlockList } = useClassBlockStore();
  const { setCanvasInfo, setName } = useWorkspaceStore();
  const { resetChangedStatusState } = useWorkspaceChangeStatusStore();
  const { setIsResetCssChecked } = useResetCssStore();
  const { setInitialImageMap, setInitialImageList } = useImageModalStore();
  const { data, isPending, isError } = useQuery({
    queryKey: workspaceKeys.detail(workspaceId),
    queryFn: () => {
      return workspaceApi.getWorkspace(userId, workspaceId);
    },
  });

  useEffect(() => {
    resetChangedStatusState();
  }, []);

  useEffect(() => {
    if (isError) {
      toast.error('워크스페이스 정보 불러오기 실패');
      return;
    }
    if (!data) {
      return;
    }

    if (!data.workspaceDto) {
      return;
    }
    setName(data.workspaceDto.name);
    Object.keys(data.workspaceDto.totalCssPropertyObj).forEach((className) => {
      createCssClassBlock(className);
    });

    initCssPropertyObj(data.workspaceDto.totalCssPropertyObj);
    initClassBlockList(
      Object.keys(data.workspaceDto.totalCssPropertyObj).map((className) =>
        removeCssClassNamePrefix(className)
      )
    );
    setCanvasInfo(data.workspaceDto.canvas);
    cssStyleToolboxConfig.contents = data.workspaceDto.classBlockList
      ? JSON.parse(data.workspaceDto.classBlockList)
      : [];
    setIsResetCssChecked(data.workspaceDto.isCssReset);
    setInitialImageMap(data.workspaceDto.imageMap);
    setInitialImageList(data.workspaceDto.imageList);
  }, [isError, data]);
  return { data, isPending, isError };
};
```
</details>

<details>
<summary>변경된 코드</summary>

```ts
export const useGetWorkspace = (workspaceId: string) => {
  const workspaceApi = WorkspaceApi();
  const userId = getUserId() || createUserId();
  const { initCssPropertyObj } = useCssPropsStore();
  const { initClassBlockList } = useClassBlockStore();
  const { setCanvasInfo, setName } = useWorkspaceStore();
  const { resetChangedStatusState } = useWorkspaceChangeStatusStore();
  const { setIsResetCssChecked } = useResetCssStore();
  const { setInitialImageMap, setInitialImageList } = useImageModalStore();
  const { data, isPending, isError } = useSuspenseQuery({
    queryKey: workspaceKeys.detail(workspaceId),
    queryFn: () => {
      resetChangedStatusState();
      return workspaceApi.getWorkspace(userId, workspaceId);
    },
  });

  useEffect(() => {
    if (!isError || !data || !data.workspaceDto) {
      return;
    }

    setName(data.workspaceDto.name);
    Object.keys(data.workspaceDto.totalCssPropertyObj).forEach((className) => {
      createCssClassBlock(className);
    });

    initCssPropertyObj(data.workspaceDto.totalCssPropertyObj);
    initClassBlockList(
      Object.keys(data.workspaceDto.totalCssPropertyObj).map((className) =>
        removeCssClassNamePrefix(className)
      )
    );
    setCanvasInfo(data.workspaceDto.canvas);
    cssStyleToolboxConfig.contents = data.workspaceDto.classBlockList
      ? JSON.parse(data.workspaceDto.classBlockList)
      : [];
    setIsResetCssChecked(data.workspaceDto.isCssReset);
    setInitialImageMap(data.workspaceDto.imageMap);
    setInitialImageList(data.workspaceDto.imageList);
  }, [isError, data]);
  return { data, isPending, isError };
};
```
</details>

- 변경 전 : `useGetWorkspace`훅에 에러 처리를 해야 했음
- 변경 후 : 데이터 페칭 성공 시 전역 상태를 초기화하는 작업만 진행

- `WorkspacePage` 컴포넌트 변경점

**기존**
```ts
  if (isError) {
    return <NotFound />;
  }

  return (
    <>
      <div className="flex h-screen flex-col">
        {isPending && <Loading />}
        {isCoachMarkOpen && <CoachMark />}
        <WorkspacePageHeader />
        <WorkspaceContent />
      </div>
      <ImageTagModal />
    </>
  );
```
- 에러, 로딩 처리를 해줘야 했음

**변경 후**
- 에러, 로딩 처리 코드 삭제
- App.tsx에서 설정하는 `createBrowserRouter`에서 `ErrorBoundary`와 `Suspense`를 통해 에리 및 로딩 처리 진행

### `useGetWorkspaceList` 훅에서 `useSuspenseInfiteQuery`를 사용하도록 교체
- useInfiteQuery -> useSuspenseQuery로 교체

- `useGetWorkspaceList` 변경점
  - `useInfiteQuery` -> `useSuspenseQuery`만 변경

- 기존 `WorkspaceContainer` 변경점
  - 기존에 사용하던  `WorkspaceContainer` 라는 컴포넌트명은 workspace만을 감싸고 있는 느낌이 강함. 하지만 `WorkspaceHeader` 컴포넌트도 감싸고 있었음
  - 의미를 명확하게 하기 위해 `WorkspaceSection`으로 컴포넌트명 변경
  - Workspace Item이 렌더링되는 부분을 `WorkspaceContainer` 컴포넌트로 분리함
  - 또한 무한스크롤, 가상스크롤 관련 로직도 제거함
  - `WorkspaceContainer` 컴포넌트를 `Suspense`로 감싸 로딩 처리 진행
 
<details>
<summary>기존 코드</summary>

```ts
export const WorkspaceContainer = () => {
  const { hasNextPage, fetchNextPage, isPending, isFetchingNextPage, isError, workspaceList } =
    useGetWorkspaceList();

  const { renderedData, offsetY, totalHeight } = useVirtualScroll<TWorkspace>({
    data: workspaceList,
    topSectionHeight: 594,
    renderedItemHeight: 262,
    gapY: 32,
  });

  const fetchCallback: IntersectionObserverCallback = (entries, observer) => {
    entries.forEach((entry) => {
      if (entry.isIntersecting && hasNextPage) {
        fetchNextPage();
        observer.unobserve(entry.target);
      }
    });
  };

  const nextFetchTargetRef = useInfiniteScroll({ intersectionCallback: fetchCallback });

  return (
    <section className="w-full max-w-[1152px] px-3 pb-48">
      <WorkspaceHeader />
      {isPending && (
        <WorkspaceGrid>
          <SkeletonWorkspaceList skeletonNum={8} />
        </WorkspaceGrid>
      )}
      {isError ? (
        <WorkspaceLoadError />
      ) : (
        workspaceList &&
        (workspaceList.length === 0 ? (
          <EmptyWorkspace />
        ) : (
          <div
            style={{
              height: `${totalHeight}px`,
            }}
          >
            <WorkspaceGrid offsetY={offsetY}>
              <WorkspaceList workspaceList={renderedData} />
              {isFetchingNextPage && <SkeletonWorkspaceList skeletonNum={8} />}
            </WorkspaceGrid>
          </div>
        ))
      )}
      {!isPending && !isFetchingNextPage && hasNextPage && (
        <div ref={nextFetchTargetRef} className="h-3 w-full"></div>
      )}
    </section>
  );
};
```
</details>

<details>
<summary>변경된 코드</summary>

```ts
export const WorkspaceSection = () => {
  return (
    <section className="w-full max-w-[1152px] px-3 pb-48">
      <WorkspaceHeader />
      <Suspense fallback={<SkeletonWorkspaceList skeletonNum={8} />}>
        <WorkspaceContainer />
      </Suspense>
    </section>
  );
};
```
</details>

- 새로운 `WorkspaceContainer` 컴포넌트
- `useGetWorkspaceList`훅을 통한 워크스페이스 데이터 페칭 진행
- `useInfiteScroll`, `useVirtualScroll` 훅을 통해 기존 무한스크롤, 가상스크롤 적용

<details>
<summary>코드</summary>

```ts
export const WorkspaceContainer = () => {
  const { hasNextPage, fetchNextPage, isPending, isFetchingNextPage, workspaceList } =
    useGetWorkspaceList();

  const { renderedData, offsetY, totalHeight } = useVirtualScroll<TWorkspace>({
    data: workspaceList,
    topSectionHeight: 594,
    renderedItemHeight: 262,
    gapY: 32,
  });

  const fetchCallback: IntersectionObserverCallback = (entries, observer) => {
    entries.forEach((entry) => {
      if (entry.isIntersecting && hasNextPage) {
        fetchNextPage();
        observer.unobserve(entry.target);
      }
    });
  };

  const nextFetchTargetRef = useInfiniteScroll({ intersectionCallback: fetchCallback });

  return (
    <>
      {workspaceList &&
        (workspaceList.length === 0 ? (
          <EmptyWorkspace />
        ) : (
          <div
            style={{
              height: `${totalHeight}px`,
            }}
          >
            <WorkspaceGrid offsetY={offsetY}>
              <WorkspaceList workspaceList={renderedData} />
              {isFetchingNextPage && <SkeletonWorkspaceList skeletonNum={8} />}
            </WorkspaceGrid>
          </div>
        ))}
      {!isPending && !isFetchingNextPage && hasNextPage && (
        <div ref={nextFetchTargetRef} className="h-3 w-full"></div>
      )}
    </>
  );
};
```
</details>


## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)
- 에러 처리를 위해 `ErrorBoundary`를 직접 구현하였으나, 이미 `react-router`에서 제공하는 `errorElement`를 통해 에러 처리를 하였기에 기존 코드를 전부 수정하는 작업은 비용이 너무 크다고 생각이 들었습니다. `Workspace` 조회 시 404 에러만 따로 처리해주는 `WorkspaceErrorPage`를 만들었습니다.
- 에러 처리 미들웨어에서 에러 발생 시 500 에러만 반환하는 문제가 있었습니다. 그래서 사용자 정의 에러들도 반환하도록 간단하게 수정했습니다.
- 400 에러와 404에러의 코드와 메세지가 뒤바뀌어 있어 수정하였습니다.

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
- 문서화를 별로하지 못했습니다. 수목에 진행해서 공유하겠습니다.
