### PR TITLE
[#21] 홈페이지 로딩 시 스켈레톤UI에 그리드가 적용되지 않는 문제 해결, 워크스페이스 로딩 화면 조건부 렌더링

### DIFF
--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -1,9 +1,9 @@
+import { DelayedFallback, Loading } from '@/shared/ui';
 import { ErrorPage, WorkspaceErrorPage } from '@/pages';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { Suspense, lazy } from 'react';
 
 import { Helmet } from 'react-helmet-async';
-import { Loading } from '@/shared/ui';
 import { ToasterWithMax } from '@/shared/ui';
 
 // lazy 로딩
@@ -49,7 +49,13 @@ const router = createBrowserRouter([
           <meta name="description" content={`워크스페이스에서 HTML과 CSS를 연습해보세요.`} />
         </Helmet>
 
-        <Suspense fallback={<Loading />}>
+        <Suspense
+          fallback={
+            <DelayedFallback>
+              <Loading />
+            </DelayedFallback>
+          }
+        >
           <WorkspacePage />
         </Suspense>
       </>

--- a/apps/client/src/shared/ui/index.ts
+++ b/apps/client/src/shared/ui/index.ts
@@ -9,6 +9,7 @@ export { ToasterWithMax } from './toast/ToasterWithMax';
 
 export { Loading } from './loading/Loading';
 export { Spinner } from './loading/Spinner';
+export { DelayedFallback } from './loading/DelayedFallback';
 
 export { SkeletonWorkspace } from './skeleton/SkeletonWorkspace';
 export { SkeletonWorkspaceList } from './skeleton/SkeletonWorkspaceList';

--- a/apps/client/src/shared/ui/loading/DelayedFallback.tsx
+++ b/apps/client/src/shared/ui/loading/DelayedFallback.tsx
@@ -1,0 +1,19 @@
+import { ReactNode, useEffect, useState } from 'react';
+
+type DelayedFallbackProps = {
+  children: ReactNode;
+  delay?: number;
+};
+
+export const DelayedFallback = ({ children, delay = 50 }: DelayedFallbackProps) => {
+  const [showFallback, setShowFallback] = useState<boolean>(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowFallback(true);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [delay]);
+
+  return <>{showFallback ? children : null} </>;
+};

--- a/apps/client/src/widgets/home/WorkspaceSection/WorkspaceSection.tsx
+++ b/apps/client/src/widgets/home/WorkspaceSection/WorkspaceSection.tsx
@@ -1,4 +1,4 @@
-import { WorkspaceContainer, WorkspaceHeader } from '@/widgets';
+import { WorkspaceContainer, WorkspaceGrid, WorkspaceHeader } from '@/widgets';
 
 import { SkeletonWorkspaceList } from '@/shared/ui';
 import { Suspense } from 'react';
@@ -12,7 +12,13 @@ export const WorkspaceSection = () => {
   return (
     <section className="w-full max-w-[1152px] px-3 pb-48">
       <WorkspaceHeader />
-      <Suspense fallback={<SkeletonWorkspaceList skeletonNum={8} />}>
+      <Suspense
+        fallback={
+          <WorkspaceGrid>
+            <SkeletonWorkspaceList skeletonNum={8} />
+          </WorkspaceGrid>
+        }
+      >
         <WorkspaceContainer />
       </Suspense>
     </section>


### PR DESCRIPTION
## 🔗 #21 

## 🙋‍ Summary (요약) 
- 홈페이지 로딩 시 스켈레톤 UI에 그리드가 적용되지 않는 문제를 해결했습니다.
- 워크스페이스 페이지로 전환될 때 로딩 시간에 따라 로딩UI 렌더링 여부를 다르게 했습니다.

## 😎 Description (변경사항)
### 스켈레톤 UI에 그리드 적용
**기존 코드**
```ts
     <Suspense fallback={<SkeletonWorkspaceList skeletonNum={8} />}>
        <WorkspaceContainer />
      </Suspense>
```

**변경된 코드**
```ts
      <Suspense
        fallback={
          <WorkspaceGrid>
            <SkeletonWorkspaceList skeletonNum={8} />
          </WorkspaceGrid>
        }
      >
        <WorkspaceContainer />
      </Suspense>
```
- Skeleton UI 컴포넌트를 WorkspaceGrid로 감쌌습니다.

### 워크스페스 페이지 전환 시 로딩 화면 조건부 렌더링
- 워크스페이스에 대한 데이터 페칭 시간이 엄청 짧아도 로딩 화면이 렌더링 되어 화면이 번쩍하는 현상이 생겼습니다.

![BooLock--Chrome2025-01-1515-53-00-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/4e2936fa-5705-4f6f-b3ef-b29ae2b7a932)

- 이를 해결하기 위해 Network 속도를 변경하며 테스트해본 결과 데이터페칭 시간이 50ms 이상일 때만 로딩화면이 렌더링되도록 `DelayedFallback`을 구현했습니다.

**코드**
```ts
type DelayedFallbackProps = {
  children: ReactNode;
  delay?: number;
};

export const DelayedFallback = ({ children, delay = 50 }: DelayedFallbackProps) => {
  const [showFallback, setShowFallback] = useState<boolean>(false);

  useEffect(() => {
    const timer = setTimeout(() => {
      setShowFallback(true);
    }, delay);
    return () => clearTimeout(timer);
  }, [delay]);

  return <>{showFallback ? children : null} </>;
};
```

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
