### PR TITLE
[HOTFIX] cicd 및 docker-compose 코드 수정

### DIFF
--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -96,7 +96,7 @@ jobs:
 
             echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
             echo "TYPE=test" >> .env
-            echo "SSL_PORT=#" >> .env
+            echo "SSL_PORT=" >> .env
             echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
             sudo docker compose pull

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -96,7 +96,7 @@ jobs:
 
             echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
             echo "TYPE=test" >> .env
-            echo "SSL_PORT=" >> .env
+            echo "SSL_PORT=#" >> .env
             echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
             sudo docker compose pull

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -77,7 +77,7 @@ jobs:
             TYPE=test
 
   deploy:
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -96,6 +96,7 @@ jobs:
 
             echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
             echo "TYPE=test" >> .env
+            echo "SSL_PORT=" >> .env
             echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
             sudo docker compose pull

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -91,8 +91,8 @@ jobs:
           script: |
             cd boolock/refactor-web31-BooLock
             git fetch origin
-            git checkout dev
-            git pull origin dev
+            git checkout HOTFIX/28
+            git pull origin HOTFIX/28
 
             echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
             echo "TYPE=test" >> .env

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -77,7 +77,7 @@ jobs:
             TYPE=test
 
   deploy:
-    # if: github.event_name == 'push'
+    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -91,8 +91,8 @@ jobs:
           script: |
             cd boolock/refactor-web31-BooLock
             git fetch origin
-            git checkout HOTFIX/28
-            git pull origin HOTFIX/28
+            git checkout dev
+            git pull origin dev
 
             echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
             echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -96,7 +96,6 @@ jobs:
 
             echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
             echo "TYPE=test" >> .env
-            echo "SSL_PORT=" >> .env
             echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
             sudo docker compose pull

--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -95,8 +95,7 @@ jobs:
             git pull origin HOTFIX/28
 
             echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
-            echo "TYPE=test" >> .env
             echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
-            sudo docker compose pull
-            sudo docker compose up -d --force-recreate --remove-orphans
+            sudo docker compose -f docker-compose.test.yml pull
+            sudo docker compose -f docker-compose.test.yml up -d --force-recreate --remove-orphans

--- a/.github/workflows/boolock-main-cicd.yml
+++ b/.github/workflows/boolock-main-cicd.yml
@@ -101,7 +101,6 @@ jobs:
             git pull origin main
 
             echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
-            echo "TYPE=prod" >> .env
             echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
             sudo docker compose pull

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,13 +1,12 @@
 services:
   frontend:
-    image: ${DOCKERHUB_USERNAME}/boolock_client_prod:latest
+    image: ${DOCKERHUB_USERNAME}/boolock_client_test:latest
     pull_policy: always
     ports:
       - '80:80'
-      - '443:443'
 
   backend:
-    image: ${DOCKERHUB_USERNAME}/boolock_server_prod:latest
+    image: ${DOCKERHUB_USERNAME}/boolock_server_test:latest
     pull_policy: always
     ports:
       - '3000:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     pull_policy: always
     ports:
       - '80:80'
-      - "${TYPE:-} == 'prod' ? '443:443' : ''"
+      - '${SSL_PORT}'
 
   backend:
     image: ${DOCKERHUB_USERNAME}/boolock_server_${TYPE}:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     pull_policy: always
     ports:
       - '80:80'
-      - '${SSL_PORT}'
+      - '${SSL_PORT-}'
 
   backend:
     image: ${DOCKERHUB_USERNAME}/boolock_server_${TYPE}:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     pull_policy: always
     ports:
       - '80:80'
-      - '${SSL_PORT-}'
+      - '${SSL_PORT:-}'
 
   backend:
     image: ${DOCKERHUB_USERNAME}/boolock_server_${TYPE}:latest


### PR DESCRIPTION
## 🔗 #28 

## 🙋‍ Summary (요약) 
- cicd deploy 과정에서 생긴 오류 수정

## 😎 Description (변경사항)
### cicd deploy 과정에서 생긴 오류 수정
- dev로 합쳐진 후 실행된 cicd deploy 과정에서 아래와 같은 오류가 발생했습니다.
![image](https://github.com/user-attachments/assets/ae7d9348-5171-4ed6-a462-343d1840245f)

```yaml
// 이전 코드
    image: ${DOCKERHUB_USERNAME}/boolock_client_${TYPE}:latest
    pull_policy: always
    ports:
      - '80:80'
      - "${TYPE:-} == 'prod' ? '443:443' : ''"
```
- docker-compose.yml 파일을 prod/test버전을 나누지 않고 env 설정에 따라 개방할 port를 달리해주려고 했으나, compose파일에서 삼항연산자가 되지 않는다는 것이었습니다.
- docker-compose.yml 파일을 prod/test버전으로 나누고 cicd 액션때 달리 사용되게 수정하였습니다.

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
