### PR TITLE
[HOTFIX] 서버 이전을 하며 workflow 및 터널링 방식 변경

### DIFF
--- a/.github/workflows/boolock-dev-cicd.yml
+++ b/.github/workflows/boolock-dev-cicd.yml
@@ -2,7 +2,10 @@ name: dev ci/cd action
 
 on:
   push:
-    branches: ['main']
+    branches: ['dev']
+  pull_request:
+    branches: ['dev']
+  workflow_dispatch:
 
 jobs:
   build:
@@ -74,26 +77,30 @@ jobs:
             DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
             TYPE=test
 
-  deploy:
-    if: github.event_name == 'push'
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy with docker
-        uses: appleboy/ssh-action@v0.1.6
-        with:
-          host: ${{ secrets.TEST_SSH_HOST }}
-          username: ${{ secrets.TEST_SSH_USER }}
-          password: ${{ secrets.TEST_SSH_PASSWORD }}
-          port: ${{ secrets.TEST_SSH_PORT }}
-          script: |
-            cd boolock/refactor-web31-BooLock
-            git fetch origin
-            git checkout dev
-            git pull origin dev
+  ## [NOTICE] 지금처럼 4대의 서버 유지가 어려워, main 서버 두개만 유지시킬 예정입니다.
+  ## 당분간은 빌드 체크만 수행하도록 합니다.
+  ## 리팩토링 작업 중 서버에 올려 실수행 과정을 체크할 필요가 있을 시 따로 말해주세요.
 
-            echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
-            echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+  # deploy:
+  #   if: github.event_name == 'push'
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Deploy with docker
+  #       uses: appleboy/ssh-action@v0.1.6
+  #       with:
+  #         host: ${{ secrets.TEST_SSH_HOST }}
+  #         username: ${{ secrets.TEST_SSH_USER }}
+  #         key: ${{ secrets.TEST_SSH_KEY }}
+  #         port: ${{ secrets.TEST_SSH_PORT }}
+  #         script: |
+  #           cd boolock/refactor-web31-BooLock
+  #           git fetch origin
+  #           git checkout hotfix_250308
+  #           git pull origin hotfix_250308
 
-            sudo docker compose -f docker-compose.test.yml pull
-            sudo docker compose -f docker-compose.test.yml up -d --force-recreate --remove-orphans
+  #           echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
+  #           echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+
+  #           sudo docker compose -f docker-compose.yml pull
+  #           sudo docker compose -f docker-compose.yml up -d --force-recreate --remove-orphans

--- a/.github/workflows/boolock-main-cicd.yml
+++ b/.github/workflows/boolock-main-cicd.yml
@@ -2,7 +2,9 @@ name: main ci/cd action
 
 on:
   push:
-    branches: ['main']
+    branches: ['dev']
+  pull_request:
+    branches: ['dev']
   workflow_dispatch:
 
 jobs:
@@ -85,25 +87,25 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Login to Docker Hub
-        run: |
-          echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+      # - name: Login to Docker Hub
+      #   run: |
+      #     echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
       - name: Deploy with docker
         uses: appleboy/ssh-action@v0.1.6
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
-          password: ${{ secrets.SSH_PASSWORD }}
+          key: ${{ secrets.TEST_SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd boolock/refactor-web31-BooLock
             git fetch origin
-            git checkout main
-            git pull origin main
+            git checkout hotfix_250308
+            git pull origin hotfix_250308
 
             echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" > .env
             echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
-            sudo docker compose pull
-            sudo docker compose up -d --force-recreate --remove-orphans
+            sudo docker compose -f docker-compose.yml pull
+            sudo docker compose -f docker-compose.yml up -d --force-recreate --remove-orphans

--- a/.github/workflows/boolock-main-cicd.yml
+++ b/.github/workflows/boolock-main-cicd.yml
@@ -2,9 +2,7 @@ name: main ci/cd action
 
 on:
   push:
-    branches: ['dev']
-  pull_request:
-    branches: ['dev']
+    branches: ['main']
   workflow_dispatch:
 
 jobs:
@@ -87,16 +85,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      # - name: Login to Docker Hub
-      #   run: |
-      #     echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-
       - name: Deploy with docker
         uses: appleboy/ssh-action@v0.1.6
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.TEST_SSH_KEY }}
+          key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           script: |
             cd boolock/refactor-web31-BooLock

--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -16,8 +16,8 @@ jobs:
           branch_name=$(jq -r .pull_request.head.ref "$GITHUB_EVENT_PATH")
           echo "Source Branch: $branch_name"
 
-          if [[ ! $branch_name =~ ^(feat/[0-9]+|bug/[0-9]+|refactor/[0-9]+|hotfix_[0-9]{4}|chore_[0-9]{4}|gh-pages)$ ]]; then
-            echo "Error: Branch name must follow the pattern 'feat/[number]', 'bug/[number]', 'hotfix_mmdd', 'chore_mmdd', or 'gh-pages'."
+          if [[ ! $branch_name =~ ^(feat/[0-9]+|bug/[0-9]+|refactor/[0-9]+|hotfix_[0-9]{4}|hotfix_[0-9]{6}|chore_[0-9]{4}|gh-pages)$ ]]; then
+            echo "Error: Branch name must follow the pattern 'feat/[number]', 'bug/[number]', 'hotfix_mmdd', 'hotfix_yymmdd', 'chore_mmdd', or 'gh-pages'."
             exit 1
           fi
 

--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -16,8 +16,8 @@ jobs:
           branch_name=$(jq -r .pull_request.head.ref "$GITHUB_EVENT_PATH")
           echo "Source Branch: $branch_name"
 
-          if [[ ! $branch_name =~ ^(feat/[0-9]+|bug/[0-9]+|refactor/[0-9]+|hotfix_[0-9]{4}|hotfix_[0-9]{6}|chore_[0-9]{4}|gh-pages)$ ]]; then
-            echo "Error: Branch name must follow the pattern 'feat/[number]', 'bug/[number]', 'hotfix_mmdd', 'hotfix_yymmdd', 'chore_mmdd', or 'gh-pages'."
+          if [[ ! $branch_name =~ ^(feat/[0-9]+|bug/[0-9]+|refactor/[0-9]+|hotfix_[0-9]{4}|hotfix_[0-9]{6}|chore_[0-9]{4}|chore_[0-9]{6}|gh-pages)$ ]]; then
+            echo "Error: Branch name must follow the pattern 'feat/[number]', 'bug/[number]', 'hotfix_mmdd', 'hotfix_yymmdd', 'chore_mmdd', 'chore_yymmdd' or 'gh-pages'."
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ swagger-output.json
 storybook-static/
 
 ssl/
+
+*.pem

--- a/apps/server/src/config/dbConnection.ts
+++ b/apps/server/src/config/dbConnection.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
 import 'dotenv/config';
 import { createTunnel } from 'tunnel-ssh';
+import fs from 'fs';
 
 const setDbConnection = async () => {
   const isLocal = process.env.IS_LOCAL === 'true';
@@ -14,7 +15,7 @@ const setDbConnection = async () => {
       host: process.env.SSH_HOST,
       port: process.env.SSH_PORT,
       username: process.env.SSH_USER,
-      password: process.env.SSH_PASSWORD,
+      privateKey: fs.readFileSync('./pem/boolock-public-key.pem'),
     };
 
     const serverOptions = {


### PR DESCRIPTION
## 🔗 Linked Issue (#40)

## 🙋‍ Summary (요약) 
- 서버 이전
- DB 이전
- ssh 연결 인증 방식 변경으로 인해 workflow 및 backend db connection 코드 수정

## 😎 Description (변경사항)
### 서버 이전
![image](https://github.com/user-attachments/assets/e5484330-eb49-4d9d-9359-90cab097dc4e)

네부캠에서 지원해준 크레딧을 거의 다 써서 aws 프리티어 사용하여 aws로 서버 이전하였습니다.

이전처럼 서버 4대를 돌리면 유지하기 어려워서 main용 서버만 돌리고 있습니다.

서버 구축 방법은 [여기](https://velog.io/@hyeonji8436/AWS-EC2%EB%A1%9C-%EC%84%9C%EB%B2%84-%EA%B5%AC%EC%B6%95%ED%95%98%EA%B8%B0)에 자세히 적어두었습니다. (깨알 블로그 홍보)

DB 이전도 마무리하고, https 도메인 ip를 이전한 서버 ip로 바꾸고 ssl 인증서 새로 발급 받고 배포하였습니다.

workflow 실행해서 cicd 동작도 문제 없이 되는 것 확인했습니다.

### DB 이전

![image](https://github.com/user-attachments/assets/96e20ac7-41f7-47cc-8c93-a959955ce339)

DB 새로 파면 유진이와 영재 눈에서 피눈물 날 걸 알기 때문에 DB도 백업해서 이전한 서버로 옮기고 복원했습니당

DB 이전에 대한 자세한 설명은 [여기](https://velog.io/@hyeonji8436/MongoDB-%EB%8B%A4%EB%A5%B8-%EC%84%9C%EB%B2%84%EB%A1%9C-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%9D%B4%EC%A0%84%ED%95%98%EA%B8%B0)에서..

### ssh 연결 인증 방식 변경으로 인해 workflow 및 backend db connection 코드 수정
NCP랑 AWS 서버 인스턴스의 큰 차이점을 아십니까? 연결 방식에 대한 허용 범위가 다릅니다..

NCP 사용할 때는 그동안 NCP 서버 콘솔에서 pem 파일 업로드해서 root 유저 password 받아서 그걸로 그냥 ssh 연결 시도하고, 패스워드 입력하고, 연결 가능했는데..! AWS는 비밀번호가 아니라 반드시 key이용만 가능합니다. 

참고로 pem 파일로 ssh key 연결방식 사용하면 cicd 연결이나, backend db 연결할 때 터널링하는 방식을 다 수정해야해서.. _~~귀차니즘 이슈로 ㅎㅎ~~_ ec2 서버에서 비밀번호 설정하고 연결해보려고 했으나 대차게 실패했습니다. (그건 트러블슈팅에서..)

``` 
  deploy:
    needs: build
    runs-on: ubuntu-latest
    steps:
      - name: Deploy with docker
        uses: appleboy/ssh-action@v0.1.6
        with:
          host: ${{ secrets.SSH_HOST }}
          username: ${{ secrets.SSH_USER }}
          key: ${{ secrets.SSH_KEY }}   # <= 여기가 원래 password였음
          port: ${{ secrets.SSH_PORT }}
```

그래서 workflow에서는 ssh 연결할 시 key 사용하게 하였고, 시크릿 키 설정해두었습니다.

``` js
    const sshOptions = {
      host: process.env.SSH_HOST,
      port: process.env.SSH_PORT,
      username: process.env.SSH_USER,
      privateKey: fs.readFileSync('./pem/boolock-public-key.pem'),
    };
```

db 커넥션 부분 코드도 ssh 터널링할 때 이렇게 privateKey로 옵션이 들어가게 수정해주었습니다.

개별적으로 수정해줘야하는 부분에 대해선 팀톡방에 별도로 설명드릴테니 수정해주시면 감사하겠습니다.

+) 추가 사항

추가로 dev 브랜치에 대한 workflow는 build 체크만 하도록 변경하였습니다. 

workflow 파일에도 주석을 달아두었지만, 만약 추가로 테스트서버를 열어서 확인해봐야 한다면 저한테 말해주세요..!

## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)
### EC2 인스턴스는 기본적으로 패스워드 연결 방식을 막고 있다.

새로 만든 서버에 ssh로 연결할 때, 기존에 쓰던 서버처럼 패스워드로 연결하고 싶어 키 설정하는 방식을 시도해보았으나 실패했습니다.

[해당 블로그](https://bgpark.tistory.com/85)에 적힌 방식처럼 시도해보았으나, 계속 `Permission denied (publickey).
lost connection` 이런 오류가 떴습니다. 

찾아보니 ec2 인스턴스에는 `ec2-instance-connect` 이 패키지가 기본적으로 깔려있는데, 이게 pem(private key) 방식 외의 시도는 막는 것 같았습니다.

저 패키지를 삭제하고 시도해보기엔... 큰 문제가 생길 것 같아 그냥 pem 방식에 맞춰 다른 코드들도 수정해주었습니다.

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
