### PR TITLE
[#42] width 브레이커 설정

### DIFF
--- a/apps/client/src/pages/HomePage/HomePage.tsx
+++ b/apps/client/src/pages/HomePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Banner, HomeHeader, WorkspaceModal, WorkspaceSection } from '@/widgets';
+import { Banner, HomeHeader, WidthBreaker, WorkspaceModal, WorkspaceSection } from '@/widgets';
 import { useClassBlockStore, useLoadingStore, useWorkspaceStore } from '@/shared/store';
 
 import { Loading } from '@/shared/ui';
@@ -29,6 +29,7 @@ export const HomePage = () => {
         <WorkspaceSection />
         <WorkspaceModal />
       </div>
+      <WidthBreaker />
     </>
   );
 };

--- a/apps/client/src/widgets/common/WidthBreaker/WidthBreaker.tsx
+++ b/apps/client/src/widgets/common/WidthBreaker/WidthBreaker.tsx
@@ -1,0 +1,19 @@
+import { useWindowSize } from '@/shared/hooks';
+
+export const WidthBreaker = () => {
+  const { screenWidth } = useWindowSize();
+
+  return (
+    <>
+      {screenWidth < 1230 ? (
+        <div className="fixed inset-0 z-50 flex h-full w-full items-center justify-center bg-gray-50/70 backdrop-blur-sm">
+          <span className="text-bold-lg text-gray-950">
+            PC 환경(너비 1230px 이상)에서만 접근 가능한 서비스입니다.
+          </span>
+        </div>
+      ) : (
+        <></>
+      )}
+    </>
+  );
+};

--- a/apps/client/src/widgets/index.ts
+++ b/apps/client/src/widgets/index.ts
@@ -18,3 +18,5 @@ export { CssPropsSelectBox } from './workspace/css/CssPropsSelectBox/CssPropsSel
 export { CssOptionItemList } from './workspace/css/CssOptionItemList/CssOptionItemList';
 export { CssPropsSelectBoxHeader } from './workspace/css/CssPropsSelectBoxHeader/CssPropsSelectBoxHeader';
 export { ImageTagModal } from './workspace/ImageTagModal/ImageTagModal';
+
+export { WidthBreaker } from './common/WidthBreaker/WidthBreaker';


### PR DESCRIPTION
## 🔗 Linked Issue (#42)

## 🙋‍ Summary (요약) 
- 최소 너비 (1230px) 이하인 디바이스에 대해 접근 금지 및 화면 블러처리로 width 브레이크 넣기

## 😎 Description (변경사항)
### 최소 너비 (1230px) 이하인 디바이스에 대해 접근 금지 및 화면 블러처리로 width 브레이크 넣기
- 모바일웹에서나, 너비가 작아질경우 서비스에 접근할 수 없게 블러처리를 해두었습니다.
- 나중엔 패드까진 쓸 수 있게 반응형으로 바꾸려구욤

![image](https://github.com/user-attachments/assets/ff635b52-da2b-4508-95fd-abdfc1e47e77)


## 🔥 Trouble Shooting (해결된 문제 및 해결 과정)

## 🤔 Open Problem (미해결된 문제 혹은 고민사항)
